### PR TITLE
Improve injection regex, fix when <head> has attributes

### DIFF
--- a/lib/jekyll-livereload/build.rb
+++ b/lib/jekyll-livereload/build.rb
@@ -19,7 +19,8 @@ module Jekyll
           end
 
           Jekyll::Hooks.register([:pages, :documents], :post_render) do |doc|
-            doc.output.sub!(/<head>(.*)<\/head>/m, "<head>\\1#{reload_script(opts)}</head>")
+            # Insert the reload_script before </head> and attempt to indent correctly
+            doc.output.sub!(%r{(\s*)(?=</head>)},   "\n\\1  #{reload_script(opts)}\\1")
           end
 
           Jekyll::Hooks.register :site, :post_write do


### PR DESCRIPTION
Instead of matching then entire `<head>...</head>` block, match the whitespace before `</head>` (using a capture group for whitespace and a lookahead for `</head>`) and then use that whitespace to try and indent the injected script correctly.

This has the advantage that we don't need to capture the entire content of `<head>...</head>` and also **won't break if <head> has attributes** or other abnormalities.

It will break, however, **if the file contains the string `"</head>"`** before the actual `</head>` closing tag (after is fine), however this is far less likely than the `<head>` tag having attributes.

The script is indented with the captured whitespace plus an additional four spaces, like so:

```
\n[captured]    <script>[captured]</head>
```

The captured whitespace is also likely to include one or more newlines, so we don't add any ourselves between `<script>` and `</head>`.

the captured whitespace is likely to be one of the following:

- Empty - the theme author has no space between the final child and the closing tag of `head`
- One or more newlines - the theme author has not indented `</head>`, instead putting it at the start of a newline.
- One or more newlines, followed by tabs or spaces - same as above, but they have also indented `</head>`.

In each of those scenarios we have a sane indentation.

The only real flaw is that while we share `</head>`'s base indentation, we only guess at the indentation of `head`'s children (4 spaces). We could use a seperate regex to capture the indentation of another `head` child, but it probably isn't worth it to make generated code that will likely never be read look perfect.