### PR TITLE
Don't register both :page and :document hooks

### DIFF
--- a/lib/jekyll-livereload/build.rb
+++ b/lib/jekyll-livereload/build.rb
@@ -18,7 +18,7 @@ module Jekyll
             end
           end
 
-          Jekyll::Hooks.register([:pages, :documents], :post_render) do |doc|
+          Jekyll::Hooks.register(:documents, :post_render) do |doc|
             doc.output.sub!(/<head>(.*)<\/head>/m, "<head>\\1#{reload_script(opts)}</head>")
           end
 


### PR DESCRIPTION
Since jekyll/jekyll#3169 both pages and posts are instances of `Jekyll::Document` so registering `:page` and `:document` hooks will trigger the listener twice.

This fixes #7