### PR TITLE
First step towards fixing #12

### DIFF
--- a/lib/jekyll-livereload/build.rb
+++ b/lib/jekyll-livereload/build.rb
@@ -33,7 +33,7 @@ module Jekyll
       private
       def reload_script(opts)
         protocol = opts[:secure] ? "https" : "http"
-        "<script src=\"#{protocol}://#{opts['host']}:#{opts['reload_port']}/livereload.js\"></script>"
+        "<script src=\"#{protocol}://#{opts['livereload_host']}:#{opts['reload_port']}/livereload.js\"></script>"
       end
 
     end

--- a/lib/jekyll-livereload/configuration.rb
+++ b/lib/jekyll-livereload/configuration.rb
@@ -4,6 +4,7 @@ module Jekyll
       private
       def load_config_options(opts)
         opts = configuration_from_options(opts)
+        opts['livereload_host'] = 'localhost' unless opts.key?('livereload_host')
         opts['host'] = 'localhost' unless opts.key?('host')
         opts['reload_port'] = Livereload::LIVERELOAD_PORT unless opts.key?('reload_port')
 


### PR DESCRIPTION
I have had similar issue as folks reporting and discussing in #12. IMHO the important think to keep in mind discussing issue #12 is that not only it seems that the host can not be correctly automatically determined in a WSL and/or Docker on Windows scenario, there is also the general use case that if jekyll runs behind a proxy the host address for the client javascript may easily differ from the host address where the websocket is running.

While writing it came to mind that another solution could also be to create the possibility that the javascript gets copied to a user defined path and then the `<javasript/>` tag is not auto injected into the `<head/>` section. That gives a user the possibility to load  `<javasript/>` from the same port (e.g. 80) as the rest of the static assets allowing to use a relative URI like e.g. `/js/livereload.js`. This then circumvents the whole issue of protocol, domain and port configuration. for loading the client javascript. And it also allows the user to better define in which pages to enable live reloading.

 
