### PR TITLE
Improved fix for #12, custom live-reload host support

### DIFF
--- a/lib/jekyll-livereload/build.rb
+++ b/lib/jekyll-livereload/build.rb
@@ -33,7 +33,7 @@ module Jekyll
       private
       def reload_script(opts)
         protocol = opts[:secure] ? "https" : "http"
-        "<script src=\"#{protocol}://#{opts['host']}:#{opts['reload_port']}/livereload.js\"></script>"
+        "<script src=\"#{protocol}://#{opts['livereload_host']}:#{opts['reload_port']}/livereload.js\"></script>"
       end
 
     end

--- a/lib/jekyll-livereload/configuration.rb
+++ b/lib/jekyll-livereload/configuration.rb
@@ -4,6 +4,7 @@ module Jekyll
       private
       def load_config_options(opts)
         opts = configuration_from_options(opts)
+        opts['livereload_host'] = 'localhost' unless opts.key?('livereload_host')
         opts['host'] = 'localhost' unless opts.key?('host')
         opts['reload_port'] = Livereload::LIVERELOAD_PORT unless opts.key?('reload_port')
 

--- a/lib/jekyll-livereload/serve.rb
+++ b/lib/jekyll-livereload/serve.rb
@@ -21,6 +21,7 @@ module Jekyll
 
       def init_with_program(prog)
         prog.command(:serve) do |c|
+          c.option 'livereload_host', '-LH', '--livereload_host', 'Host to serve live-reload on'
           c.option 'livereload', '-L', '--livereload', 'Inject Livereload.js and run a WebSocket Server'
           c.option 'reload_port', '-R', '--reload_port [PORT]', Integer, 'Port to serve Livereload on'
         end

--- a/lib/jekyll-livereload/websocket.rb
+++ b/lib/jekyll-livereload/websocket.rb
@@ -102,7 +102,7 @@ module Jekyll
           EM.epoll
           EM.run do
             protocol = @opts[:secure] ? "https" : "http"
-            Jekyll.logger.info("LiveReload Server:", "#{protocol}://#{@opts['host']}:#{@opts['reload_port']}")
+            Jekyll.logger.info("LiveReload Server:", "#{protocol}://#{@opts['livereload_host']}:#{@opts['reload_port']}")
             EM.start_server(@opts['host'], @opts['reload_port'], HttpAwareConnection, @opts) do |ws|
               ws.onopen do |handshake|
                 connect(ws, handshake)


### PR DESCRIPTION
This is an improvement on the patch by @renzok, adds support for logging the new host and there also needed to be a change to the monkey patch for jekyll.

This is working for me now.